### PR TITLE
Update for crystal 1.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     container:
-      image: crystallang/crystal:0.35.1-alpine
+      image: crystallang/crystal:1.0.0-alpine
     steps:
     - uses: actions/checkout@v2
     - name: Install system dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     container:
-      image: crystallang/crystal:0.35.1-alpine
+      image: crystallang/crystal:1.0.0-alpine
     steps:
     - uses: actions/checkout@v2
     - name: Install system dependencies

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.4.0
 authors:
   - Alex Ling <email@hkalexling.com>
 
-crystal: 0.35.1
+crystal: 1.0.0
 
 license: MIT
 


### PR DESCRIPTION
Update crystal requirement to avoid needing `--ignore-crystal-version` workaround.